### PR TITLE
Min and max zoom level options for markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 pkg/*
 pkg/**/*
+*.swp
+*.swo
+*.scratch.*
+.DS_Store
+.bundle
+.rvmrc

--- a/README.markdown
+++ b/README.markdown
@@ -138,9 +138,15 @@ These are options that can be passed to the `jMapping` function to change specif
 * `force_zoom_level`:
   * *Default*: *N/A*
   * This will force the map to **always** be rendered at this zoom level.
+* `marker_max_zoom`:
+  * *Default*: `null`
+  * Use this option to set the maximum zoom level for your markers. If you zoom in beyond this level, Markers will not be visible. If a null value is used, the maximum map zoom level will be assumed.
+* `marker_min_zoom`:
+  * *Default*: `9`
+  * Use this option to set the minimum zoom level for your markers. If you zoom out beyond this level, Markers will not be visible.
 * `always_show_markers`:
   * *Default*: `false`
-  * Set this option to `true` if you wish to display markers on all zoom levels. (Normally, the markers may only be visible on certain zoom levels, depending on the normal bounds and zoom level of the marker data.)
+  * Set this option to `true` to display markers on all zoom levels and override the `marker_min_zoom` and `marker_max_zoom` values.
 
 Object API
 -----------

--- a/jquery.jmapping.js
+++ b/jquery.jmapping.js
@@ -191,11 +191,12 @@
       var updateMarkerManager = function(){
         if (settings.always_show_markers === true) {
           min_zoom = 0;
+          max_zoom = null;
         } else {
-          zoom_level = map.getZoom();
-          min_zoom = (zoom_level < 7) ? 0 : (zoom_level - 7);
+          min_zoom = settings.marker_min_zoom;
+          max_zoom = settings.marker_max_zoom;
         }
-        markerManager.addMarkers(gmarkersArray(), min_zoom);
+        markerManager.addMarkers(gmarkersArray(), min_zoom, max_zoom);
         markerManager.refresh();
         if (settings.force_zoom_level){
           map.setZoom(settings.force_zoom_level);
@@ -266,7 +267,9 @@
       info_window_selector: '.info-box',
       info_window_max_width: 425,
       default_point: {lat: 0.0, lng: 0.0},
-      metadata_options: {type: 'attr', name: 'data-jmapping'}
+      metadata_options: {type: 'attr', name: 'data-jmapping'},
+      marker_max_zoom: null,
+      marker_min_zoom: 9
     },
     makeGLatLng: function(place_point){
       return new google.maps.LatLng(place_point.lat, place_point.lng);

--- a/spec/spec_helper.js
+++ b/spec/spec_helper.js
@@ -60,7 +60,6 @@ Screw.Specifications.mockGMapsUpdate = function(){
   // mock out GMap2
   var gmap_mock = Smoke.Mock();
   gmap_mock.should_receive('fitBounds').exactly('twice');
-  gmap_mock.should_receive('getZoom').exactly('once').and_return(10);
   $.extend(google.maps.Map.prototype, gmap_mock);
   
   // mock out Bounds


### PR DESCRIPTION
Hi!

I found some odd marker behavior when they were created outside the MarkerManger's maxZoom.

This commit provides settings options for min and max marker zoom levels with reasonable defaults.

I'm not too familiar with Smoke and couldn't find a way to set an expectation that the MarkerManager constructor is called with the maxZoom option. Perhaps you know how???

Thanks for all the hard work!
Greg
